### PR TITLE
Improved functionality for 32 bit applications

### DIFF
--- a/QtREAnalzyer/src/main/java/qtreanalzyer/QtClassSolver.java
+++ b/QtREAnalzyer/src/main/java/qtreanalzyer/QtClassSolver.java
@@ -111,9 +111,15 @@ public class QtClassSolver {
 		InstructionIterator instructions = listing.getInstructions(metaObject.getBody(), true);
 		while(instructions.hasNext()) {
 			Instruction instruction = instructions.next();
-			if(instruction.getMnemonicString().equals("LEA")) {
+			String mnemonic = instruction.getMnemonicString();
+			if(mnemonic.equals("LEA") || mnemonic.equals("MOV")) {
+				if(instruction.getOperandReferences(1).length <= 0) {
+					continue;
+				}
 				reference = instruction.getOperandReferences(1)[0];
-				return reference.getToAddress();
+				if(reference.getReferenceType().isData()) {
+					return reference.getToAddress();
+				}
 			}
 		}
 		return null;

--- a/QtREAnalzyer/src/main/java/qtreanalzyer/QtClassSolver.java
+++ b/QtREAnalzyer/src/main/java/qtreanalzyer/QtClassSolver.java
@@ -145,7 +145,9 @@ public class QtClassSolver {
 		DataType intDataType = program.getDataTypeManager().getDataType("/int");
 		int intLenght = intDataType.getLength();
 		
-		Address strdata0IndexAddr = qtMetaStringdataAddress.add(intLenght * 4);
+		// Calculate the offset within the QArrayData struct to the "offset" field
+		int strdata0IndexOffset = qtTypesManager.getQArrayData().getComponent(4).getOffset();
+		Address strdata0IndexAddr = qtMetaStringdataAddress.add(strdata0IndexOffset);
 		long stringdata0Index = memory.getLong(strdata0IndexAddr);
 		
 		DataType qByteArrayData = qtTypesManager.getQByteArrayData();

--- a/QtREAnalzyer/src/main/java/qtreanalzyer/QtTypesManager.java
+++ b/QtREAnalzyer/src/main/java/qtreanalzyer/QtTypesManager.java
@@ -13,6 +13,7 @@ import ghidra.program.model.data.DataType;
 import ghidra.program.model.data.DataTypeConflictHandler;
 import ghidra.program.model.data.DataTypeManager;
 import ghidra.program.model.data.EnumDataType;
+import ghidra.program.model.data.InvalidDataTypeException;
 import ghidra.program.model.data.PointerDataType;
 import ghidra.program.model.data.Structure;
 import ghidra.program.model.data.StructureDataType;
@@ -92,8 +93,8 @@ public class QtTypesManager {
 				qArrayData = new StructureDataType(QT_ROOT, "QArrayData", 0, dataTypeManager);
 				qArrayData.add(dataTypeManager.getDataType("/int"), "ref", null);
 				qArrayData.add(dataTypeManager.getDataType("/int"), "size", null);
-				qArrayData.add(dataTypeManager.getDataType("/uint"), "alloc", null);
-				qArrayData.add(dataTypeManager.getDataType("/uint"), "capacityReserved", null);
+				qArrayData.addBitField(dataTypeManager.getDataType("/uint"), 31, "alloc", null);
+				qArrayData.addBitField(dataTypeManager.getDataType("/uint"), 1, "capacityReserved", null);
 				qArrayData.add(dataTypeManager.getDataType("/void *"), "offset", null);
 				qArrayData.setToDefaultPacking();
 				qArrayData = (Structure) dataTypeManager.addDataType(qArrayData, DataTypeConflictHandler.REPLACE_HANDLER);
@@ -120,7 +121,7 @@ public class QtTypesManager {
 				superData.add(new PointerDataType(qMetaObject), "direct", null);
 				superData.setToDefaultPacking();
 				
-			} catch (ParseException e) {
+			} catch (ParseException | InvalidDataTypeException e) {
 				// TODO Auto-generated catch block
 				e.printStackTrace();
 			}
@@ -132,7 +133,7 @@ public class QtTypesManager {
 			return qtTypesManager;
 		}
 		
-		public DataType getQArrayData() {
+		public Structure getQArrayData() {
 			return qArrayData;
 		}
 		


### PR DESCRIPTION
There are two main changes to improve functionality for 32 bit applications

1. Find the staticMetaObject also by "MOV" instructions where the second operand is data
2. Change QArrayData to use bit fields for alloc and capacityReserved. This appears give correct functionality on both 32 and 64 bit applications